### PR TITLE
Bug fix: playback drag slider when playing; quit when playing.

### DIFF
--- a/include/glwidget.h
+++ b/include/glwidget.h
@@ -40,11 +40,9 @@ class GLWidget : public QOpenGLWidget, protected QOpenGLFunctions_4_3_Core
         void SetTrackingEnabled(bool enable);
 
     public slots:
-//        void ZoomPlus();
-//        void ZoomMinus();
+
         void UpdateGrid();
         void Disconnected();
-//        void StopTracking();
         void StartTracking();
         void ResetCameraAll();
         void ResetCameraOrient();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -82,11 +82,10 @@ MainWindow::MainWindow(QWidget *parent)
     ui_->glLayout_2->addWidget(glWidget2_);
     glWidget2_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
-//    installEventFilter(this);
     ConnectSignalsToSlots();
-    InitLoadConfigure();
     InitComboBoxes();
     InitLaneTypeMenu();
+    InitLoadConfigure();
 
     QSurfaceFormat format;
     format.setDepthBufferSize(24);
@@ -788,13 +787,13 @@ MainWindow::UpdateConfigure()
         config_.ch1PlaybackDataType_ = (DataType)ui_->playbackDataType->currentIndex();
     }
 
-    if(hasChange)
-        config_.Save();
-
     if(config_.ch1DeltaDelay_ != ui_->deltaDelay->text().toInt())
     {
         config_.ch1DeltaDelay_ = ui_->deltaDelay->text().toInt();
+        config_.Save();
     }
+    else if(hasChange)
+        config_.Save();
 
     return hasChange;
 }
@@ -834,13 +833,13 @@ MainWindow::UpdateConfigure2()
         config_.ch2PlaybackDataType_ = (DataType)ui_->playbackDataType_2->currentIndex();
     }
 
-    if(hasChange)
-        config_.Save();
-
     if(config_.ch2DeltaDelay_ != ui_->deltaDelay_2->text().toInt())
     {
         config_.ch2DeltaDelay_ = ui_->deltaDelay_2->text().toInt();
+        config_.Save();
     }
+    else if(hasChange)
+        config_.Save();
 
     return hasChange;
 }
@@ -864,6 +863,7 @@ MainWindow::InitLoadConfigure()
         ui_->playbackDataType_2->setCurrentIndex( static_cast<int>(config_.ch2PlaybackDataType_) );
         ui_->deltaDelay_2->setText(QString::number(config_.ch2DeltaDelay_));
 
+        ui_->actionCombiCh->setChecked(config_.combineChannel_);
         ui_->actionShowGrid->setChecked(config_.showGrid_);
         ui_->actionShowObject->setChecked(config_.showObjectDetails_);
         ui_->actionLockCamera->setChecked(config_.lockCamera_);
@@ -988,6 +988,7 @@ void
 MainWindow::CombineChannels()
 {
     config_.combineChannel_ = !config_.combineChannel_;
+    config_.Save();
 }
 
 void

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1514</width>
-    <height>1029</height>
+    <width>1076</width>
+    <height>926</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -1411,7 +1411,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1514</width>
+     <width>1076</width>
      <height>22</height>
     </rect>
    </property>

--- a/src/osireader.cpp
+++ b/src/osireader.cpp
@@ -286,6 +286,7 @@ void
 OsiReader::SendMessageLoop()
 {
     std::ifstream inputFile (osiFileName_.toStdString().c_str());
+    bool isFirstMessage (true);
 
     while(isRunning_)
     {
@@ -301,9 +302,9 @@ OsiReader::SendMessageLoop()
 
             uint64_t firstTimeStamp (0);
             uint64_t preTimeStamp (0);
-            bool isFirstMessage (true);
+            bool isRefreshMessage (true);
 
-            while(getline(inputFile, str_line_input) && !isPaused_)
+            while(getline(inputFile, str_line_input) && !isPaused_ && isRunning_)
             {
                 if(iterChanged_)
                     break;
@@ -332,9 +333,15 @@ OsiReader::SendMessageLoop()
                     if(isFirstMessage)
                     {
                         firstTimeStamp = curStamp;
-                        preTimeStamp = curStamp;
                         isFirstMessage = false;
                     }
+
+                    if(isRefreshMessage)
+                    {
+                        preTimeStamp = curStamp;
+                        isRefreshMessage = false;
+                    }
+
                     int64_t sleep = curStamp - preTimeStamp;
                     if(sleep < 0)
                         sleep = 0;


### PR DESCRIPTION
Fix the following bugs:
1. When playing in playback mode, user can't friendly drag the slider to specified position. The slider jumps back to origin.
2. When playing in playback mode, user can't quit directly. Program got frozen.