### PR TITLE
Add new functionality: send out osi::sensordata to network while playing playback files

### DIFF
--- a/include/appconfig.h
+++ b/include/appconfig.h
@@ -24,6 +24,8 @@ class AppConfig
         QString  ch1LoadFile_;
         DataType ch1PlaybackDataType_;
         int      ch1DeltaDelay_;
+        bool     ch1EnableSendOut_;
+        QString  ch1SendOutPortNum_;
 
         QString  ch2IPAddress_;
         QString  ch2PortNum_;
@@ -31,6 +33,8 @@ class AppConfig
         QString  ch2LoadFile_;
         DataType ch2PlaybackDataType_;
         int      ch2DeltaDelay_;
+        bool     ch2EnableSendOut_;
+        QString  ch2SendOutPortNum_;
 
         bool combineChannel_;
         bool showGrid_;

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -97,6 +97,9 @@ class MainWindow : public QMainWindow
         void LoadFileEdited2(const QString& text);
         void LoadFileBrowse2();
 
+        void EnableSendToNetwork();
+        void EnableSendToNetwork2();
+
         void PlayPauseButtonClicked();
         void PlayPauseButtonClicked2();
 

--- a/include/osireader.h
+++ b/include/osireader.h
@@ -11,6 +11,8 @@
 #include <osi/osi_version.pb.h>
 #include <osi/osi_sensordata.pb.h>
 
+#include <zmq.hpp>
+
 #include <fstream>
 #include <iostream>
 #include <unistd.h>
@@ -27,7 +29,13 @@ class OsiReader: public QObject, public IMessageSource
     Q_OBJECT
 
     public:
-        OsiReader(int* deltaDelay);
+        OsiReader(int* deltaDelay,
+                  const bool& enableSendOut,
+                  const std::string& zmqPubPortNum);
+
+        QString SetupConnection(bool enable);
+
+        void SetSendOutPortNum(const std::string& port) { zmqPubPortNumber_ = port; }
 
         signals:
             void Connected(DataType dataType);
@@ -52,6 +60,8 @@ class OsiReader: public QObject, public IMessageSource
 
         void SendMessageLoop();
 
+        void ZMQSendOutMessage(const osi::SensorData& sd);
+
 
 
         bool isRunning_;
@@ -68,6 +78,11 @@ class OsiReader: public QObject, public IMessageSource
         std::vector<std::pair<uint64_t, std::streamoff> >::iterator newIterStamp_;
 
         const int* const deltaDelay_;
+
+        const bool&     enableSendOut_;
+        std::string     zmqPubPortNumber_;
+        zmq::context_t  zmqContext_;
+        zmq::socket_t   zmqPublisher_;
 
         // read from input file: data type is always SensorData
         DataType defaultDatatype_ = DataType::Groundtruth;

--- a/src/appconfig.cpp
+++ b/src/appconfig.cpp
@@ -13,6 +13,8 @@ AppConfig::AppConfig(QString fileName)
     , ch1LoadFile_("")
     , ch1PlaybackDataType_(DataType::Groundtruth)
     , ch1DeltaDelay_(0)
+    , ch1EnableSendOut_(false)
+    , ch1SendOutPortNum_("5564")
 
     , ch2IPAddress_("")
     , ch2PortNum_("")
@@ -20,6 +22,8 @@ AppConfig::AppConfig(QString fileName)
     , ch2LoadFile_("")
     , ch2PlaybackDataType_(DataType::Groundtruth)
     , ch2DeltaDelay_(0)
+    , ch2EnableSendOut_(false)
+    , ch2SendOutPortNum_("5564")
 
     , combineChannel_(false)
     , showGrid_(true)
@@ -58,16 +62,20 @@ AppConfig::Load()
     ch1DataType_   = (DataType)root.elementsByTagName("CH1DataType").at(0).toElement().text().toInt();
     ch1LoadFile_   = root.elementsByTagName("CH1LoadFile").at(0).toElement().text();
     ch1PlaybackDataType_ = (DataType)root.elementsByTagName("CH1PlaybackDataType").at(0).toElement().text().toInt();
-    ch1DeltaDelay_ = root.elementsByTagName("CH1DeltaDelay").at(0).toElement().text().toInt();
+    ch1DeltaDelay_       = root.elementsByTagName("CH1DeltaDelay").at(0).toElement().text().toInt();
+    ch1EnableSendOut_    = root.elementsByTagName("CH1EnableSendOut").at(0).toElement().text() == "1" ? true : false;
+    ch1SendOutPortNum_   = root.elementsByTagName("CH1SendOutPortNumber").at(0).toElement().text();
 
     ch2IPAddress_  = root.elementsByTagName("CH2IpAddress").at(0).toElement().text();
     ch2PortNum_    = root.elementsByTagName("CH2PortNumber").at(0).toElement().text();
     ch2DataType_   = (DataType)root.elementsByTagName("CH2DataType").at(0).toElement().text().toInt();
     ch2LoadFile_   = root.elementsByTagName("CH2LoadFile").at(0).toElement().text();
     ch2PlaybackDataType_ = (DataType)root.elementsByTagName("CH2PlaybackDataType").at(0).toElement().text().toInt();
-    ch2DeltaDelay_ = root.elementsByTagName("CH2DeltaDelay").at(0).toElement().text().toInt();
+    ch2DeltaDelay_       = root.elementsByTagName("CH2DeltaDelay").at(0).toElement().text().toInt();
+    ch2EnableSendOut_    = root.elementsByTagName("CH2EnableSendOut").at(0).toElement().text() == "1" ? true : false;
+    ch2SendOutPortNum_   = root.elementsByTagName("CH2SendOutPortNumber").at(0).toElement().text();
 
-    combineChannel_ = root.elementsByTagName("CombineChannel").at(0).toElement().text() == "1" ? true : false;
+    combineChannel_    = root.elementsByTagName("CombineChannel").at(0).toElement().text() == "1" ? true : false;
     showGrid_          = root.elementsByTagName("ShowGrid").at(0).toElement().text() == "1" ? true : false;
     showObjectDetails_ = root.elementsByTagName("ShowObjectDetails").at(0).toElement().text() == "1" ? true : false;
     lockCamera_        = root.elementsByTagName("LockCamera").at(0).toElement().text() == "1" ? true : false;
@@ -109,6 +117,8 @@ AppConfig::Save()
     writer.writeTextElement("CH1LoadFile", ch1LoadFile_);
     writer.writeTextElement("CH1PlaybackDataType", QString::number(static_cast<int>(ch1PlaybackDataType_)));
     writer.writeTextElement("CH1DeltaDelay", QString::number(static_cast<int>(ch1DeltaDelay_)));
+    writer.writeTextElement("CH1EnableSendOut", QString::number(ch1EnableSendOut_));
+    writer.writeTextElement("CH1SendOutPortNumber", ch1SendOutPortNum_);
 
     writer.writeTextElement("CH2IpAddress", ch2IPAddress_);
     writer.writeTextElement("CH2PortNumber", ch2PortNum_);
@@ -116,6 +126,8 @@ AppConfig::Save()
     writer.writeTextElement("CH2LoadFile", ch2LoadFile_);
     writer.writeTextElement("CH2PlaybackDataType", QString::number(static_cast<int>(ch2PlaybackDataType_)));
     writer.writeTextElement("CH2DeltaDelay", QString::number(static_cast<int>(ch2DeltaDelay_)));
+    writer.writeTextElement("CH2EnableSendOut", QString::number(ch2EnableSendOut_));
+    writer.writeTextElement("CH2SendOutPortNumber", ch2SendOutPortNum_);
 
     writer.writeTextElement("CombineChannel", QString::number(combineChannel_));
     writer.writeTextElement("ShowGrid", QString::number(showGrid_));

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -254,7 +254,7 @@
            </layout>
           </item>
           <item>
-           <layout class="QVBoxLayout" name="verticalLayout_10" stretch="0,0,0,0,0,0,0,0,0,1">
+           <layout class="QVBoxLayout" name="verticalLayout_10" stretch="0,0,0,0,0,0,0,0,0,0,1">
             <item>
              <widget class="QRadioButton" name="rbConnection">
               <property name="sizePolicy">
@@ -599,6 +599,59 @@
              </layout>
             </item>
             <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_16" stretch="0,0,0,1">
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <spacer name="horizontalSpacer_23">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="enableSendToNetwork">
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="text">
+                 <string>Send to Port:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLineEdit" name="sendOutPortNum">
+                <property name="maximumSize">
+                 <size>
+                  <width>60</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_25">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
              <spacer name="verticalSpacer">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
@@ -924,7 +977,7 @@
            </layout>
           </item>
           <item>
-           <layout class="QVBoxLayout" name="verticalLayout_14" stretch="0,0,0,0,0,0,0,0,0,1">
+           <layout class="QVBoxLayout" name="verticalLayout_14" stretch="0,0,0,0,0,0,0,0,0,0,1">
             <item>
              <widget class="QRadioButton" name="rbConnection_2">
               <property name="sizePolicy">
@@ -1148,7 +1201,7 @@
             <item>
              <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,1">
               <property name="bottomMargin">
-               <number>10</number>
+               <number>0</number>
               </property>
               <item>
                <spacer name="horizontalSpacer_22">
@@ -1166,7 +1219,7 @@
               <item>
                <widget class="QLabel" name="label_14">
                 <property name="text">
-                 <string>Data:</string>
+                 <string>Data: </string>
                 </property>
                </widget>
               </item>
@@ -1228,6 +1281,59 @@
               </item>
               <item>
                <spacer name="horizontalSpacer_19">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_17" stretch="0,0,0,1">
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <spacer name="horizontalSpacer_24">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="enableSendToNetwork_2">
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="text">
+                 <string>Send to Port:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLineEdit" name="sendOutPortNum_2">
+                <property name="maximumSize">
+                 <size>
+                  <width>60</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_26">
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
                 </property>

--- a/src/tcpreceiver.cpp
+++ b/src/tcpreceiver.cpp
@@ -87,7 +87,7 @@ TCPReceiver::DisconnectRequested()
     }
     catch (zmq::error_t& error)
     {
-        message = "Error connecting to endpoint: " + QString::fromUtf8(error.what());
+        message = "Error disconnecting endpoint: " + QString::fromUtf8(error.what());
     }
 
     isConnected_ = false;


### PR DESCRIPTION
User can specify a network port number when using playback functionality.
Then the complete osi::sensordata will be sent out.