### PR TITLE
Fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ or just manually if dependecies are already installed:
 ```bash
 $ git clone https://github.com/OpenSimulationInterface/osi-visualizer.git
 $ cd osi-visualizer
-$ git clone https://github.com/OpenSimulationInterface/open-simulation-interface
+$ git submodule update --init
 $ mkdir build
 $ cd build
 $ cmake ..

--- a/install.sh
+++ b/install.sh
@@ -63,7 +63,7 @@ echo "
 # Installing OSI 3                                                                    
 #################################
 "
-git clone https://github.com/OpenSimulationInterface/open-simulation-interface.git;
+git submodule update --init
 cd open-simulation-interface;
 git clone https://github.com/OpenSimulationInterface/proto2cpp.git;
 mkdir -p build;


### PR DESCRIPTION
Currently the instructions instruct people to independently clone OSI, instead of using the submodule mechanism, as intended. Also fix the install.sh script in that small regard. However that script should be rethought completely anyway, given that it does dangerous sudo stuff that has no place in an install script, has misconceptions about shell syntax, does not install but rather runs osi-visualizer in place, and is a bad idea as is.

#### Check the checklist

- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests / travis ci pass locally with my changes.