### PR TITLE
Read osi format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ proto/generated/
 
 # build folder
 build
+cmake-build-debug
 osi-visualizer
 
 # Qtcreator project file
@@ -43,3 +44,7 @@ CMakeLists.txt.user
 
 # Config file
 appconfig.xml
+
+# Directories
+.idea/
+.vscode/

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,6 @@
 	path = open-simulation-interface
 	url = https://github.com/OpenSimulationInterface/open-simulation-interface.git
 
-[submodule "osi-sensor-model-packaging"]
-	path = osi-sensor-model-packaging
-	url = https://github.com/OpenSimulationInterface/osi-sensor-model-packaging.git
+[submodule "proto2cpp"]
+	path = proto2cpp
+	url = https://github.com/OpenSimulationInterface/proto2cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
 [submodule "open-simulation-interface"]
 	path = open-simulation-interface
 	url = https://github.com/OpenSimulationInterface/open-simulation-interface.git
-
-[submodule "proto2cpp"]
-	path = proto2cpp
-	url = https://github.com/OpenSimulationInterface/proto2cpp.git

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ OSI Visualizer serves as a visualization tool for the current implementation of 
 
 ## Usage
 
-Use the configuration panel at the right (see Screenshot below) to load e.g. a playback file for channel 1 at `Playback` and choose a port to which it will be send (here 5564). Select the data type `SensorView` according to the content of the file. After that enter into the IP field the `localhost` and into the port field the receiving port (here 5563) for channel 2 in the panel below at `Connection`. Select the data type it is expected to visualize (here `SensorData`). In this example an intermediary on localhost processes the data from the input file using a [OSMP](https://github.com/OpenSimulationInterface/osi-sensor-model-packaging) sensor model, transforms it into `SensorData` and sends it to port 5563.
+Use the configuration panel at the right (see Screenshot below) to load e.g. a [OSI trace file](https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/doc/fileformat.html) for channel 1 at `Playback` and choose a port to which it will be send (here 5564). Select the data type `SensorView` according to the content of the file. After that enter into the IP field the `localhost` and into the port field the receiving port (here 5563) for channel 2 in the panel below at `Connection`. Select the data type it is expected to visualize (here `SensorData`). In this example an intermediary on localhost processes the data from the input file using a [OSMP](https://github.com/OpenSimulationInterface/osi-sensor-model-packaging) sensor model, transforms it into `SensorData` and sends it to port 5563.
 
 ![](resources/Images/Over_View.png)
 

--- a/include/osireader.h
+++ b/include/osireader.h
@@ -26,7 +26,7 @@ class OsiReader : public QObject, public IMessageSource
     Q_OBJECT
 
   public:
-    OsiReader(int* deltaDelay, const bool& enableSendOut, const std::string& pubPortNum, int socketType);
+    OsiReader(const int* deltaDelay, const bool& enableSendOut, std::string  pubPortNum, int socketType);
 
     QString SetupConnection(bool enable);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -334,7 +334,7 @@ void MainWindow::LoadFileBrowse()
 {
     QString fileName = ui_->loadFile->text();
 
-    fileName = QFileDialog::getOpenFileName(this, tr("Load file"), fileName, tr("Text Files (*.txt)"));
+    fileName = QFileDialog::getOpenFileName(this, tr("Load file"), fileName, tr("OSI Files (*.txt *.osi)"));
 
     if (!fileName.isEmpty())
     {
@@ -353,7 +353,7 @@ void MainWindow::LoadFileBrowse2()
 {
     QString fileName = ui_->loadFile_2->text();
 
-    fileName = QFileDialog::getOpenFileName(this, tr("Load file"), fileName, tr("Text Files (*.txt)"));
+    fileName = QFileDialog::getOpenFileName(this, tr("Load file"), fileName, tr("OSI Files (*.txt *.osi)"));
 
     if (!fileName.isEmpty())
     {

--- a/src/osiparser.cpp
+++ b/src/osiparser.cpp
@@ -7,6 +7,7 @@
 #include <QMessageBox>
 
 #include <cmath>
+#include <string>
 
 /*
  *
@@ -68,8 +69,15 @@ void OsiParser::LocalMonitor(const T& data)
     {
         ++osiMsgNumber_;
 
+        unsigned int message_size = data.SerializeAsString().size();
+        unsigned char ch[4];
+        memcpy(ch, (char*)&message_size, sizeof(unsigned int));
+
+        osiMsgString_ += ch[0];
+        osiMsgString_ += ch[1];
+        osiMsgString_ += ch[2];
+        osiMsgString_ += ch[3];
         osiMsgString_ += data.SerializeAsString();
-        osiMsgString_ += "$$__$$";
     }
     else if (osiMsgNumber_ >= config_.osiMsgSaveThreshold_)
     {
@@ -566,16 +574,16 @@ void OsiParser::ParseSensorDataStationaryObject(Message& objectMessage,
 // Export Osi message
 void OsiParser::ExportOsiMessage()
 {
-    if (startSaveOSIMsg_ == false && osiMsgString_.empty() == true)
+    if (!startSaveOSIMsg_ && osiMsgString_.empty())
     {
         startSaveOSIMsg_ = true;
     }
-    else if (startSaveOSIMsg_ == true && osiMsgString_.empty() == false)
+    else if (startSaveOSIMsg_ && !osiMsgString_.empty())
     {
         startSaveOSIMsg_ = false;
 
-        QString fileName = QFileDialog::getSaveFileName(nullptr, "Export message to file", "", "*.txt");
-        if (fileName.isEmpty() == false)
+        QString fileName = QFileDialog::getSaveFileName(nullptr, "Export message to osi trace file", "", "*.osi");
+        if (!fileName.isEmpty())
         {
             QFile file(fileName);
             if (!file.open(QIODevice::WriteOnly))

--- a/src/osireader.cpp
+++ b/src/osireader.cpp
@@ -590,6 +590,7 @@ void OsiReader::SendMessageLoop()
         fclose(fd);
     }
     else {
+        std::cout << "[WARNING]: The $$__$$ separated trace files will be completely removed in the near future and be replaced with the length separated OSI trace files. Please convert them to *.osi files with the converter in the main OSI repository or record the current trace file into the OSI format." << std::endl;
         std::ifstream inputFile(osiFileName_.toStdString().c_str(), std::ios::binary);
         while (isRunning_)
         {


### PR DESCRIPTION
#### Reference to a related issue in the repository
The [PR](https://github.com/OpenSimulationInterface/open-simulation-interface/pull/358) which defines the new OSI file format and its benefits.

#### Add a description
**What is this change?**
This PR adds the feature for the osi visualizer to read and record OSI trace files in  the new osi file format which is length separated.

**Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?**
This PR is a feature and does not break any functionality and is still backwards compatible since the old txt separated by $$__$$ trace files can still be read. The recording will always output the OSI trace format to motivate user to use the new file format. 

**How has it been tested?**
The functionality has been tested with multiple txt and osi trace files. The output of the recording has been used again as a input to see if the visualizer recognizes the format.

**Change notes:**
- Extended input files to *.txt and *.osi
- Added two functions (`read_bytes`, `realloc_buffer`) for reading and allocating in the new file format
- Recorder export outputs now **only** to *.osi
- Removed OSMP from gitmodule
- Simplyfiction of some expression like `if(var==true)` -->` if(var)`
- Changed nanoseconds and slidervalue to uint64_t
- replaced `push_back(std::make_pair(` with `emplace_back(`

#### Mention a member
@jdsika @pmai let me know your thoughts, suggestions and improvements! Thanks ;)

#### Check the checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.