### PR TITLE
Fix fmi installation and replace docker with explicit build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
 # Change directory back to default build directory.
 before_script:
     - cd "${TRAVIS_BUILD_DIR}"
+    - sudo apt-get update && sudo apt-get upgrade && sudo apt-get autoremove
     - sudo bash install-deps.sh
     - sudo bash build-install-build-deps.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,42 @@
+# Define Distribution
+dist: bionic
+
 # Use C++ build environment.
 language: cpp
 
 sudo: required
 
-# We use docker-based builds to enable current Ubuntu LTS BuildEnv
-services:
-    - docker
+# Protobuf requires g++ (see https://github.com/google/protobuf/blob/master/src/README.md)
+compiler:
+    - gcc
 
+# Handle dependencies in separate directory.
 before_install:
-    - docker build -t osi-standard/osi-visualizer .
+    - DEPS_DIR="${HOME}/deps"
+    - mkdir -p "${DEPS_DIR}"
+    - cd "${DEPS_DIR}"
 
-# Run the build script.
+# Install necessary packages.
+install:
+    # Install a recent version of CMake
+    - |
+        CMAKE_URL="https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz"
+        if [ ! -f ${DEPS_DIR}/cmake/bin/cmake ] ; then mkdir -p cmake ; travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake ; fi
+        export PATH=${DEPS_DIR}/cmake/bin:${PATH}
+
+    # Install a recent version of the Protobuf
+    - |
+        PROTOBUF_URL="https://github.com/google/protobuf/releases/download/v3.2.0/protobuf-cpp-3.2.0.tar.gz"
+        if [ ! -f ${DEPS_DIR}/protobuf/install/bin/protoc ] ; then mkdir -p protobuf ; travis_retry wget --no-check-certificate --quiet -O - ${PROTOBUF_URL} | tar --strip-components=1 -xz -C protobuf ; cd protobuf ; ./configure --prefix=${DEPS_DIR}/protobuf/install ; make ; make install ; fi
+        export PATH=${DEPS_DIR}/protobuf/install/bin:${PATH}
+        
+
+# Change directory back to default build directory.
+before_script:
+    - cd "${TRAVIS_BUILD_DIR}"
+    - bash install-deps.sh
+    - bash build-install-build-deps.sh
+
+# Run the build script
 script:
-    - docker run -it -v $(pwd):/project osi-standard/osi-visualizer /bin/sh -c "mkdir -p build && cd build && cmake .. && cmake --build ."
+    - bash build.sh   

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,6 @@ install:
         if [ ! -f ${DEPS_DIR}/cmake/bin/cmake ] ; then mkdir -p cmake ; travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake ; fi
         export PATH=${DEPS_DIR}/cmake/bin:${PATH}
 
-    # Install a recent version of the Protobuf
-    - |
-        PROTOBUF_URL="https://github.com/google/protobuf/releases/download/v3.2.0/protobuf-cpp-3.2.0.tar.gz"
-        if [ ! -f ${DEPS_DIR}/protobuf/install/bin/protoc ] ; then mkdir -p protobuf ; travis_retry wget --no-check-certificate --quiet -O - ${PROTOBUF_URL} | tar --strip-components=1 -xz -C protobuf ; cd protobuf ; ./configure --prefix=${DEPS_DIR}/protobuf/install ; make ; make install ; fi
-        export PATH=${DEPS_DIR}/protobuf/install/bin:${PATH}
-        
-
 # Change directory back to default build directory.
 before_script:
     - cd "${TRAVIS_BUILD_DIR}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ install:
 # Change directory back to default build directory.
 before_script:
     - cd "${TRAVIS_BUILD_DIR}"
-    - bash install-deps.sh
-    - bash build-install-build-deps.sh
+    - sudo bash install-deps.sh
+    - sudo bash build-install-build-deps.sh
 
 # Run the build script
 script:

--- a/build-install-build-deps.sh
+++ b/build-install-build-deps.sh
@@ -24,45 +24,37 @@ echo "
 mkdir -p fmi_library
 cd fmi_library
 
-FMI_lib_version=2.0.2
-
 fmi_library_include_install_dir=/usr/local/include/fmi-library
 fmi_library_lib_install_dir=/usr/local/lib/fmi-library
 
-if ! [ -e ${fmi_library_include_install_dir} -a -e ${fmi_library_lib_install_dir} ]
+if ! [ -e ${fmi_library_include_install_dir} -a -e ${fmi_library_lib_install_dir} ] 
 then
-echo "
-Downloading FMI library...
-"
+  echo "Downloading FMI library..."
 
-if [ ! -d $FMI_lib_version ]
-then
-  wget --no-parent -nH --cut-dirs=2 -r https://svn.jmodelica.org/FMILibrary/tags/$FMI_lib_version/
-fi
+  if [ ! -d FMILibrary-2.0.2 ] 
+  then
+    wget --no-parent -nH --cut-dirs=2 -r https://jmodelica.org/FMILibrary/FMILibrary-2.0.2-src.zip
+  fi
 
-echo "
-Building FMI library...
-"
-  cd ${FMI_lib_version}
+  echo "Building FMI library..."
+  unzip FMILibrary-2.0.2-src.zip
+  cd FMILibrary-2.0.2
   mkdir -p build
   cd build
-  cmake ../. -DCMAKE_BUILD_TYPE=RELEASE
+  cmake ..
+  make -j8
   make -j8 install
-  cd ..
-  if [[ -d "install" ]]
+  cd ../install
+
+  if [ ! -d ${fmi_library_include_install_dir} ] 
   then
-    cd install
-      mkdir -p ${fmi_library_include_install_dir}
-    if [[ -d ${fmi_library_include_install_dir} ]]
-    then
-      cp -uvrf ./include/* ${fmi_library_include_install_dir}/
-    fi
-    mkdir -p ${fmi_library_lib_install_dir}
-    if [[ -d ${fmi_library_lib_install_dir} ]]
-    then
-      cp -uvrf ./lib/* ${fmi_library_lib_install_dir}/
-    fi
-  else
-    echo "Could not install the fmi-library into usr/local"
+  sudo mkdir -p ${fmi_library_include_install_dir}
+  sudo cp -uvrf ./include/* ${fmi_library_include_install_dir}/
+  fi
+
+  if [ ! -d ${fmi_library_lib_install_dir} ] 
+  then
+  sudo mkdir -p ${fmi_library_lib_install_dir}
+  sudo cp -uvrf ./lib/* ${fmi_library_lib_install_dir}/
   fi
 fi

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -42,4 +42,4 @@ echo "
 # Installing OpenGL                                                                   
 #################################
 "
-apt-get install libgl1-mesa-dev libgl1-mesa-dri libgl1-mesa-glx -y
+apt-get install libgl1-mesa-dev libgl1-mesa-dri libgl1-mesa-glx libqt5opengl5-dev -y


### PR DESCRIPTION
#### Reference to a related issue in the repository
An [issue](https://github.com/OpenSimulationInterface/osi-visualizer/issues/46) occured during installation of the fmi library from the script `build-install-build-deps.sh`.

#### Add a description

**What is this change?**
This PR fixes the FMI installation in the script `build-install-build-deps.sh`. Furthermore I replace the docker osi-visualizer build with the explicit scripts which are provided by the repo for building the osi-visualizer to catch such errors in the issue in future. I also added the library `libqt5opengl5-dev` for the dependecy installation since the travis ci complained about it.

#### Mention a member
@jdsika @pmai pls review. Thanks!

#### Check the checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.