### PR TITLE
Ensure .osi opened in binary mode

### DIFF
--- a/src/osireader.cpp
+++ b/src/osireader.cpp
@@ -172,7 +172,7 @@ void OsiReader::SliderValueChanged(int newValue)
         if (std::regex_search(osiFileName_.toStdString().c_str(), osi_regex)){
 
             typedef unsigned int message_size_t;
-            FILE *fd = fopen(osiFileName_.toStdString().c_str(), "r");
+            FILE *fd = fopen(osiFileName_.toStdString().c_str(), "rb");
             if (fd == nullptr) {
                 perror("Open failed");
             }
@@ -333,7 +333,7 @@ bool OsiReader::CreateHeader(QString& errorMsg)
     const std::regex osi_regex("\\.osi");
 
     if (std::regex_search(osiFileName_.toStdString().c_str(), osi_regex)){
-        FILE *fd = fopen(osiFileName_.toStdString().c_str(), "r");
+        FILE *fd = fopen(osiFileName_.toStdString().c_str(), "rb");
         if (fd == nullptr) {
             perror("Open failed");
             return -1;
@@ -490,7 +490,7 @@ void OsiReader::SendMessageLoop()
     std::regex osi_regex("\\.osi");
 
     if (std::regex_search(osiFileName_.toStdString().c_str(), osi_regex)){
-        FILE *fd = fopen(osiFileName_.toStdString().c_str(), "r");
+        FILE *fd = fopen(osiFileName_.toStdString().c_str(), "rb");
         if (fd == nullptr) {
             perror("Open failed");
         }


### PR DESCRIPTION
Building and executing osi-visualizer for Windows I got a strange error message, "Wrong file format", when trying to open *.osi files, even though the file is correct.

The problem is in the fopen function call. "r" seems to work fine on Linux platform, but on Windows reading of messages will fail with error message "Wrong file format" as a result. Probably Windows assumes ASCII format and reads only part of messages, for some reason. 

Debug analysis: fread returns a number less than the message size, leading to another read operation wich then returns 0.

Changing mode to "rb" fixes the problem.


#### Check the checklist

- [x ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests / travis ci pass locally with my changes.